### PR TITLE
Сheck rspec prefix to automatically detect RSpec parser

### DIFF
--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -51,6 +51,21 @@ func TestFindParser(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			desc: "finds rspec parser automatically for the suite with rspec prefix",
+			name: "auto",
+			path: fileloader.Ensure(bytes.NewReader([]byte(`
+				<?xml version="1.0"?>
+					<testsuite name="rspec1">
+						<testcase name="bar">
+						</testcase>
+						<testcase name="baz">
+						</testcase>
+					</testsuite>
+			`))),
+			want:    RSpec{},
+			wantErr: false,
+		},
+		{
 			desc: "finds exunit parser automatically",
 			name: "auto",
 			path: fileloader.Ensure(bytes.NewReader([]byte(`

--- a/pkg/parsers/rspec.go
+++ b/pkg/parsers/rspec.go
@@ -37,7 +37,7 @@ func (me RSpec) IsApplicable(path string) bool {
 		for attr, value := range xmlElement.Attributes {
 			switch attr {
 			case "name":
-				if value == "rspec" {
+				if strings.HasPrefix(value, "rspec") {
 					return true
 				}
 			}


### PR DESCRIPTION
I found an interesting behavior for `test-results` parser autodetect mode if you are using it with the `parallel_test` gem and RspecJunitFormatter.

Let's start from the `parallel_test` [gem](https://github.com/grosser/parallel_tests), it can automatically split tests and you can run tests in parallel on one machine. Each "thread" has a TEST_ENV_NUMBER variable and it allows you to setup different databases, for example, or save reports to different files.

The `rspec_junit_formatter` gem can generate report in the special format required for Semaphore CI. It also can work with parallel tests as described [here](https://github.com/sj26/rspec_junit_formatter#parallel-tests).

But if we check the [code](https://github.com/sj26/rspec_junit_formatter/blob/d20e820866067838265c3cab253aae7086dd8340/lib/rspec_junit_formatter.rb#L19) for the report generator, we can find that it uses a TEST_ENV_NUMBER variable in the name. The reports generated via the `rspec_junit_formatter` gem with `parallel_test` have rspec1 (depends on `first-is-1` config), rspec2, ... names in the `<testsuite>` tag.

It means `test-results` parser will not detect these reports as RSpec and will use a generic parser. Because of this you will see strange suites on the test results page with the names rspec1, rspec2, ... instead of spec paths.

P.S. I'm not a Go developer, this code changed only based on language documentation from the Internet and I can miss some best practices. Feel free to change it or add some comments. Thanks!