### PR TITLE
Add flags to control stdout/stdin

### DIFF
--- a/cmd/combine.go
+++ b/cmd/combine.go
@@ -60,6 +60,12 @@ var combineCmd = &cobra.Command{
 			result.Combine(*newResult)
 		}
 
+		err = cli.DecorateResults(&result, cmd)
+		if err != nil {
+			logger.Error("Decorating results failed with error: %v", err)
+			return err
+		}
+
 		jsonData, err := cli.Marshal(result)
 		if err != nil {
 			return err
@@ -74,5 +80,7 @@ var combineCmd = &cobra.Command{
 }
 
 func init() {
+	combineCmd.Flags().Int32P("trim-output-to", "s", 0, "trim stdout to N characters, defaults to 0(unlimited)")
+	combineCmd.Flags().BoolP("omit-output-for-passed", "o", false, "omit stdout if test passed, defaults to false")
 	rootCmd.AddCommand(combineCmd)
 }

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -161,6 +161,8 @@ func init() {
 	desc := `Skips uploading raw XML files`
 	publishCmd.Flags().BoolP("no-raw", "", false, desc)
 	publishCmd.Flags().BoolP("force", "f", false, "force artifact push, passes -f flag to artifact CLI")
+	publishCmd.Flags().Int32P("trim-output-to", "s", 0, "trim stdout to N characters, defaults to 0(unlimited)")
+	publishCmd.Flags().BoolP("omit-output-for-passed", "o", false, "omit stdout if test passed, defaults to false")
 
 	rootCmd.AddCommand(publishCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ import (
 
 var cfgFile string
 
-var versionString = "0.6.4"
+var versionString = "0.6.5"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/priv/parsers/stdout/in.xml
+++ b/priv/parsers/stdout/in.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="stdout testing">
+    <testcase name="trims stdout">
+      <system-out>assume-im-long-out</system-out>
+      <failure message="Assertion with == failed">I've failed</failure>
+    </testcase>
+    <testcase name="trims stderr">
+      <system-err>assume-im-longerr</system-err>
+      <failure message="Assertion with == failed">I've failed as well</failure>
+    </testcase>
+    <testcase name="trims stderr" system-out="assume-im-long-but-also-ive-succeeded"></testcase>
+  </testsuite>
+</testsuites>

--- a/priv/parsers/stdout/out.json
+++ b/priv/parsers/stdout/out.json
@@ -1,0 +1,147 @@
+{
+  "testResults": [
+    {
+      "id": "4ae71336-e44b-39bf-b9d2-752e234818a5",
+      "name": "",
+      "framework": "",
+      "isDisabled": false,
+      "suites": [
+        {
+          "id": "5adf0dab-e505-39fe-99c7-298ef43a8f09",
+          "name": "foo",
+          "isSkipped": false,
+          "isDisabled": false,
+          "timestamp": "",
+          "hostname": "",
+          "package": "",
+          "tests": [
+            {
+              "id": "03038e64-7367-39b9-8e6c-5f503139a200",
+              "file": "",
+              "classname": "",
+              "package": "",
+              "name": "foo.2",
+              "duration": 0,
+              "state": "passed",
+              "failure": null,
+              "error": null,
+              "systemOut": "",
+              "systemErr": ""
+            },
+            {
+              "id": "58f2ffeb-dc64-3100-b81f-cfc2e9646b8b",
+              "file": "",
+              "classname": "",
+              "package": "",
+              "name": "foo.1",
+              "duration": 0,
+              "state": "passed",
+              "failure": null,
+              "error": null,
+              "systemOut": "",
+              "systemErr": ""
+            },
+            {
+              "id": "7c947655-ee72-38d1-965d-35a6bdb0da6d",
+              "file": "",
+              "classname": "",
+              "package": "",
+              "name": "foo.4",
+              "duration": 0,
+              "state": "passed",
+              "failure": null,
+              "error": null,
+              "systemOut": "",
+              "systemErr": ""
+            },
+            {
+              "id": "b6941c19-0674-36aa-965c-badc07c512bd",
+              "file": "",
+              "classname": "",
+              "package": "",
+              "name": "foo.3",
+              "duration": 0,
+              "state": "passed",
+              "failure": null,
+              "error": null,
+              "systemOut": "",
+              "systemErr": ""
+            }
+          ],
+          "properties": null,
+          "summary": {
+            "total": 4,
+            "passed": 4,
+            "skipped": 0,
+            "error": 0,
+            "failed": 0,
+            "disabled": 0,
+            "duration": 0
+          },
+          "systemOut": "",
+          "systemErr": ""
+        },
+        {
+          "id": "c348fb08-df86-3e06-a356-b951c48ea5a4",
+          "name": "bar",
+          "isSkipped": false,
+          "isDisabled": false,
+          "timestamp": "",
+          "hostname": "",
+          "package": "",
+          "tests": [
+            {
+              "id": "0727aa44-1fc5-3024-804f-6e5936caa480",
+              "file": "",
+              "classname": "",
+              "package": "",
+              "name": "bar.1",
+              "duration": 0,
+              "state": "passed",
+              "failure": null,
+              "error": null,
+              "systemOut": "",
+              "systemErr": ""
+            },
+            {
+              "id": "30daf1b2-b6e9-382f-836d-a13f7a7cddac",
+              "file": "",
+              "classname": "",
+              "package": "",
+              "name": "bar.2",
+              "duration": 0,
+              "state": "passed",
+              "failure": null,
+              "error": null,
+              "systemOut": "",
+              "systemErr": ""
+            }
+          ],
+          "properties": null,
+          "summary": {
+            "total": 2,
+            "passed": 2,
+            "skipped": 0,
+            "error": 0,
+            "failed": 0,
+            "disabled": 0,
+            "duration": 0
+          },
+          "systemOut": "",
+          "systemErr": ""
+        }
+      ],
+      "summary": {
+        "total": 6,
+        "passed": 6,
+        "skipped": 0,
+        "error": 0,
+        "failed": 0,
+        "disabled": 0,
+        "duration": 0
+      },
+      "status": "success",
+      "statusMessage": ""
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces two new flags to the test results CLI:

- `--trim-output-to N`(`-s N`) - trim system output length to `N` characters. The default value is `0` (unlimited)
- `--omit-output-for-passed` (`-o`) - removes system output for tests that passed