### PR TITLE
Close temporary file after writing parsed test results

### DIFF
--- a/cmd/combine.go
+++ b/cmd/combine.go
@@ -71,7 +71,7 @@ var combineCmd = &cobra.Command{
 			return err
 		}
 
-		_, err = cli.WriteToFile(jsonData, output)
+		_, err = cli.WriteToFilePath(jsonData, output)
 		if err != nil {
 			return err
 		}

--- a/cmd/compile.go
+++ b/cmd/compile.go
@@ -79,7 +79,7 @@ var compileCmd = &cobra.Command{
 				return err
 			}
 
-			_, err = cli.WriteToFile(jsonData, tmpFile.Name())
+			_, err = cli.WriteToFilePath(jsonData, tmpFile.Name())
 			if err != nil {
 				return err
 			}
@@ -96,7 +96,7 @@ var compileCmd = &cobra.Command{
 			return err
 		}
 
-		_, err = cli.WriteToFile(jsonData, output)
+		_, err = cli.WriteToFilePath(jsonData, output)
 		if err != nil {
 			return err
 		}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -78,7 +78,7 @@ var publishCmd = &cobra.Command{
 				return err
 			}
 
-			_, err = cli.WriteToFile(jsonData, tmpFile.Name())
+			_, err = cli.WriteToFile(jsonData, tmpFile)
 			if err != nil {
 				return err
 			}

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -82,6 +82,11 @@ var publishCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
+
+			err = tmpFile.Close()
+			if err != nil {
+				return err
+			}
 		}
 
 		result, err := cli.MergeFiles(dirPath, cmd)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -193,8 +193,12 @@ func Marshal(testResults parser.Result) ([]byte, error) {
 	return jsonData, nil
 }
 
-// WriteToFile saves data to given file
-func WriteToFile(data []byte, path string) (string, error) {
+func WriteToFile(data []byte, file *os.File) (string, error) {
+	return writeToFile(data, file)
+}
+
+// WriteToFilePathPath saves data to given file
+func WriteToFilePath(data []byte, path string) (string, error) {
 	file, err := os.Create(path) // #nosec
 	defer file.Close()
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -3,10 +3,11 @@ package cli_test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/semaphoreci/test-results/pkg/parser"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/semaphoreci/test-results/pkg/parser"
+	"github.com/stretchr/testify/require"
 
 	"github.com/semaphoreci/test-results/pkg/cli"
 	"github.com/stretchr/testify/assert"
@@ -136,7 +137,7 @@ func TestWriteToTmpFile(t *testing.T) {
 	})
 }
 
-func TestWriteToFile(t *testing.T) {
+func TestWriteToFilePath(t *testing.T) {
 	tr := parser.TestResults{
 		ID:         "1234",
 		Name:       "Test",
@@ -159,7 +160,7 @@ func TestWriteToFile(t *testing.T) {
 	jsonData, _ := json.Marshal(&result)
 
 	t.Run("Write to one file", func(t *testing.T) {
-		file, err := cli.WriteToFile(jsonData, "out")
+		file, err := cli.WriteToFilePath(jsonData, "out")
 		assert.NoError(t, err)
 		os.Remove(file)
 	})
@@ -175,7 +176,7 @@ func TestWriteToFile(t *testing.T) {
 			tmpFile, err := os.CreateTemp(dirPath, "result-*.json")
 			require.NoError(t, err)
 
-			_, err = cli.WriteToFile(jsonData, tmpFile.Name())
+			_, err = cli.WriteToFilePath(jsonData, tmpFile.Name())
 			require.NoError(t, err)
 		}
 	})


### PR DESCRIPTION
We are opening the same file multiple times: 
```
tmpFile, err := os.CreateTemp(dirPath, "result-*.json")
			if err != nil {
				return err
			}
```
and then again in the `cli.WriteToFile`: ([here](https://github.com/semaphoreci/test-results/blob/master/pkg/cli/cli.go#L198))
```
			_, err = cli.WriteToFile(jsonData, tmpFile.Name())
			if err != nil {
				return err
			}
```
Since we are looping over paths we need to close the file explicitly and not using defer statement.
